### PR TITLE
ENH Add identifiers to phpstan rules.

### DIFF
--- a/src/PHPStan/KeywordSelfRule.php
+++ b/src/PHPStan/KeywordSelfRule.php
@@ -23,6 +23,8 @@ use PHPStan\Rules\RuleErrorBuilder;
  */
 class KeywordSelfRule implements Rule
 {
+    public const IDENTIFIER = 'keyword.self';
+
     public function getNodeType(): string
     {
         return Node::class;
@@ -69,7 +71,7 @@ class KeywordSelfRule implements Rule
         return [
             RuleErrorBuilder::message(
                 "Can't use keyword 'self'. Use '$actualClass' instead."
-            )->build()
+            )->identifier(self::IDENTIFIER)->build()
         ];
     }
 }

--- a/src/PHPStan/MethodAnnotationsRule.php
+++ b/src/PHPStan/MethodAnnotationsRule.php
@@ -30,6 +30,8 @@ use SilverStripe\ORM\ManyManyThroughList;
  */
 class MethodAnnotationsRule implements Rule
 {
+    public const IDENTIFIER = 'annotations.method';
+
     private ReflectionProvider $reflectionProvider;
 
     public function __construct(ReflectionProvider $reflectionProvider)
@@ -69,7 +71,7 @@ class MethodAnnotationsRule implements Rule
             if (!array_key_exists($methodName, $expectedAnnotations)) {
                 $errors[] = RuleErrorBuilder::message(
                     "@method annotation '$annotationString' isn't expected and should be removed."
-                )->build();
+                )->identifier(self::IDENTIFIER)->build();
                 continue;
             }
 
@@ -78,7 +80,7 @@ class MethodAnnotationsRule implements Rule
                 $errors[] = RuleErrorBuilder::message(
                     "@method annotation '$annotationString' should be removed,"
                     . " because a method named '$methodName' already exists."
-                )->build();
+                )->identifier(self::IDENTIFIER)->build();
                 continue;
             }
 
@@ -87,7 +89,7 @@ class MethodAnnotationsRule implements Rule
                 $count = $annotationData['count'];
                 $errors[] = RuleErrorBuilder::message(
                     "@method annotation '$annotationString' appears $count times. Remove the duplicates."
-                )->build();
+                )->identifier(self::IDENTIFIER)->build();
                 continue;
             }
 
@@ -103,7 +105,7 @@ class MethodAnnotationsRule implements Rule
                         $shortClassName = $this->getShortClassName($returnClassName);
                         $errors[] = RuleErrorBuilder::message(
                             "@method annotation '$annotationString' needs a use statement for class '$shortClassName'."
-                        )->build();
+                        )->identifier(self::IDENTIFIER)->build();
                         continue;
                     }
                 }
@@ -111,7 +113,7 @@ class MethodAnnotationsRule implements Rule
                 // Complain about type mismatches
                 $errors[] = RuleErrorBuilder::message(
                     "@method annotation '$annotationString' should be '$expectedAnnotationString'."
-                )->build();
+                )->identifier(self::IDENTIFIER)->build();
                 continue;
             }
 
@@ -120,7 +122,7 @@ class MethodAnnotationsRule implements Rule
             if ($annotationString !== $expectedAnnotationString) {
                 $errors[] = RuleErrorBuilder::message(
                     "@method annotation '$annotationString' should be '$expectedAnnotationString'."
-                )->build();
+                )->identifier(self::IDENTIFIER)->build();
                 continue;
             }
         }
@@ -136,7 +138,7 @@ class MethodAnnotationsRule implements Rule
             $expectedAnnotationString = $missingData['annotationString'];
             $errors[] = RuleErrorBuilder::message(
                 "@method annotation '$expectedAnnotationString' is missing or has an invalid syntax."
-            )->build();
+            )->identifier(self::IDENTIFIER)->build();
         }
 
         return $errors;

--- a/src/PHPStan/TranslationFunctionRule.php
+++ b/src/PHPStan/TranslationFunctionRule.php
@@ -27,6 +27,8 @@ use PHPStan\Type\Generic\GenericClassStringType;
  */
 class TranslationFunctionRule implements Rule
 {
+    public const IDENTIFIER = 'translation.key';
+
     public function getNodeType(): string
     {
         return Node::class;
@@ -109,12 +111,16 @@ class TranslationFunctionRule implements Rule
             return [
                 RuleErrorBuilder::message(
                     'Can\'t determine value of first argument to _t(). Use a simpler value.'
-                )->build()
+                )->identifier(self::IDENTIFIER)->build()
             ];
         }
 
         if (substr_count($argValue, '.') !== 1) {
-            return [RuleErrorBuilder::message('First argument passed to _t() must have exactly one period.')->build()];
+            return [
+                RuleErrorBuilder::message(
+                    'First argument passed to _t() must have exactly one period.'
+                )->identifier(self::IDENTIFIER)->build()
+            ];
         }
 
         return [];


### PR DESCRIPTION
PHPStan errors need an identifier in order to be ignored: https://phpstan.org/user-guide/ignoring-errors

The docs don't talk about ignoring errors from custom rules, but we can see this being done in the built-in rules, e.g https://github.com/phpstan/phpstan-src/blob/1.12.x/src/Rules/FunctionCallParametersCheck.php#L596

## Issue
- https://github.com/silverstripe/silverstripe-framework/issues/11325