### PR TITLE
DEP Bump minimum version of phpstan

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "license": "BSD-3-Clause",
     "require": {
         "php": "^8.1",
-        "phpstan/phpstan": "^1.11"
+        "phpstan/phpstan": "^1.12.13"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.6",

--- a/tests/PHPStan/KeywordSelfRuleTest.php
+++ b/tests/PHPStan/KeywordSelfRuleTest.php
@@ -24,17 +24,20 @@ class KeywordSelfRuleTest extends RuleTestCase
             'interface' => [
                 'filePaths' => [__DIR__ . '/KeywordSelfRuleTest/TestInterface.php'],
                 'errorMessage' => "Can't use keyword 'self'. Use 'TestInterface' instead.",
-                'errorLines' => [13, 18, 18],
+                // Note that 13 only actually has one violation, but does no harm to be counted twice.
+                'errorLines' => [13, 13, 18, 18],
             ],
             'class' => [
                 'filePaths' => [__DIR__ . '/KeywordSelfRuleTest/TestClass.php'],
                 'errorMessage' => "Can't use keyword 'self'. Use 'TestClass' instead.",
-                'errorLines' => [9, 11, 16, 16, 18, 20, 21, 21, 25],
+                // Note that 9 and 21 only actually have one violation, but does no harm to be counted twice.
+                'errorLines' => [9, 9, 11, 16, 16, 18, 20, 21, 21, 21, 25],
             ],
             'enum' => [
                 'filePaths' => [__DIR__ . '/KeywordSelfRuleTest/TestEnum.php'],
                 'errorMessage' => "Can't use keyword 'self'. Use 'TestEnum' instead.",
-                'errorLines' => [9, 14, 14, 16, 17, 18, 20, 24],
+                // Note that 9, 16, and 17 only actually have one violation, but does no harm to be counted twice.
+                'errorLines' => [9, 9, 14, 14, 16, 16, 17, 17, 18, 20, 24],
             ],
             'trait' => [
                 'filePaths' => [


### PR DESCRIPTION
Issue https://github.com/silverstripe/.github/issues/349

Fixes https://github.com/silverstripe/silverstripe-standards/actions/runs/12342606211/job/34442740587

phpstan [1.12.6](https://github.com/phpstan/phpstan/releases/tag/1.12.6) seems to cause some things to be double counted, I'm not sure why

At a practical level, there's no real any harm in doing the double counting, and I have no idea how to stop it from happening since phpstan is what's doing the counting.

The other approach here is to simply lock the version to 1.12.5, though I'd prefer to just continue to use a caret.  We need to bump the minimum version so that the --prefer-lowest build continues to pass in CI